### PR TITLE
Support Device ID and Device UID

### DIFF
--- a/AudioSwitcher.xcodeproj/project.pbxproj
+++ b/AudioSwitcher.xcodeproj/project.pbxproj
@@ -148,6 +148,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ENABLE_OBJC_WEAK = YES;
+				ARCHS = "$(ARCHS_STANDARD)";
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_MODEL_TUNING = G5;
@@ -162,6 +163,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ENABLE_OBJC_WEAK = YES;
+				ARCHS = "$(ARCHS_STANDARD)";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_MODEL_TUNING = G5;
 				INSTALL_PATH = /usr/local/bin;

--- a/README.md
+++ b/README.md
@@ -25,13 +25,14 @@ switchaudio-osx requires command line tools to be installed from OS X. To instal
 Usage
 -----
 
-SwitchAudioSource [-a] [-c] [-t type] [-n] -s device\_name | -i device\_id 
+SwitchAudioSource [-a] [-c] [-t type] [-n] -s device\_name | -i device\_id | -u device\_uid 
 
  - **-a**               : shows all devices
  - **-c**               : shows current device
  - **-t** _type_        : device type (input/output/system).  Defaults to output.
  - **-n**               : cycles the audio device to the next one
  - **-i** _device_id_   : sets the audio device to the given device by id
+ - **-u** _device_uid_   : sets the audio device to the given device by uid or a substring of the uid
  - **-s** _device_name_ : sets the audio device to the given device by name
 
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This utility switches the audio source for Mac OS X.
 
 You specify the name of the audio source, such as Built-in Digital Output, and the utility switches the source immediately without any GUI interaction.
 
-This is a command-line utility only and has no graphical user interface.  Tested on OS 10.7 - 10.10.
+This is a command-line utility only and has no graphical user interface.  Tested on OS 10.7 - 10.13.
 
 Installing from homebrew
 ------------------------
@@ -25,12 +25,13 @@ switchaudio-osx requires command line tools to be installed from OS X. To instal
 Usage
 -----
 
-SwitchAudioSource [-a] [-c] [-t type] [-n] -s device_name  
+SwitchAudioSource [-a] [-c] [-t type] [-n] -s device\_name | -i device\_id 
 
  - **-a**               : shows all devices
  - **-c**               : shows current device
  - **-t** _type_        : device type (input/output/system).  Defaults to output.
  - **-n**               : cycles the audio device to the next one
+ - **-i** _device_id_   : sets the audio device to the given device by id
  - **-s** _device_name_ : sets the audio device to the given device by name
 
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ SwitchAudioSource [-a] [-c] [-t type] [-n] -s device\_name | -i device\_id | -u 
 
  - **-a**               : shows all devices
  - **-c**               : shows current device
+ - **-f** _format_      : output format (cli/human/json). Defaults to human.
  - **-t** _type_        : device type (input/output/system).  Defaults to output.
  - **-n**               : cycles the audio device to the next one
  - **-i** _device_id_   : sets the audio device to the given device by id

--- a/audio_switch.c
+++ b/audio_switch.c
@@ -179,6 +179,12 @@ int runAudioSwitch(int argc, const char * argv[]) {
         }
         strcpy(printableDeviceName, requestedDeviceName);
     }
+
+    if (!chosenDeviceID) {
+        printf("Please specify audio device.\n");
+        showUsage(argv[0]);
+        return 1;
+    }
 	
 	// choose the requested audio device
 	setDevice(chosenDeviceID, typeRequested);

--- a/audio_switch.c
+++ b/audio_switch.c
@@ -31,7 +31,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 
 void showUsage(const char * appName) {
-	printf("Usage: %s [-a] [-c] [-t type] [-n] -s device_name\n"
+	printf("Usage: %s [-a] [-c] [-t type] [-n] -s device_name | -i device_id\n"
            "  -a             : shows all devices\n"
            "  -c             : shows current device\n\n"
            "  -f format      : output format (cli/human/json). Defaults to human.\n"

--- a/audio_switch.c
+++ b/audio_switch.c
@@ -37,6 +37,7 @@ void showUsage(const char * appName) {
            "  -f format      : output format (cli/human/json). Defaults to human.\n"
            "  -t type        : device type (input/output/system).  Defaults to output.\n"
            "  -n             : cycles the audio device to the next one\n"
+           "  -i device_id   : sets the audio device to the given device by id\n"
            "  -s device_name : sets the audio device to the given device by name\n\n",appName);
 }
 

--- a/audio_switch.c
+++ b/audio_switch.c
@@ -43,13 +43,15 @@ void showUsage(const char * appName) {
 
 int runAudioSwitch(int argc, const char * argv[]) {
 	char requestedDeviceName[256];
+    char printableDeviceName[256];
+    int requestedDeviceID;
 	AudioDeviceID chosenDeviceID = kAudioDeviceUnknown;
 	ASDeviceType typeRequested = kAudioTypeUnknown;
 	ASOutputType outputRequested = kFormatHuman;
 	int function = 0;
 
 	int c;
-	while ((c = getopt(argc, (char **)argv, "hacnt:f:s:")) != -1) {
+	while ((c = getopt(argc, (char **)argv, "hacnt:f:i:s:")) != -1) {
 		switch (c) {
 			case 'f':
 				// format
@@ -84,11 +86,17 @@ int runAudioSwitch(int argc, const char * argv[]) {
 				function = kFunctionCycleNext;
 				break;
 				
-			case 's':
-				// set the requestedDeviceName
-				function = kFunctionSetDevice;
-				strcpy(requestedDeviceName, optarg);
+			case 'i':
+				// set the requestedDeviceID
+				function = kFunctionSetDeviceByID;
+                requestedDeviceID = atoi(optarg);
 				break;
+
+            case 's':
+                // set the requestedDeviceName
+                function = kFunctionSetDeviceByName;
+                strcpy(requestedDeviceName, optarg);
+                break;
 
 			case 't':
 				// set the requestedDeviceName
@@ -156,25 +164,27 @@ int runAudioSwitch(int argc, const char * argv[]) {
 		
 		return 0;
 	}
-	
-	if (function != kFunctionSetDevice) {
-		printf("Please specify audio device.\n");
-		showUsage(argv[0]);
-		return 1;
-	}
-	
-	// find the id of the requested device
-	chosenDeviceID = getRequestedDeviceID(requestedDeviceName, typeRequested);
-	if (chosenDeviceID == kAudioDeviceUnknown) {
-		printf("Could not find an audio device named \"%s\" of type %s.  Nothing was changed.\n",requestedDeviceName, deviceTypeName(typeRequested));
-		return 1;
-	}
+
+    if (function == kFunctionSetDeviceByID) {
+        chosenDeviceID = (AudioDeviceID)requestedDeviceID;
+        sprintf(printableDeviceName, "Device with ID: %d", chosenDeviceID);
+    }
+
+    if (function == kFunctionSetDeviceByName) {
+        // find the id of the requested device
+        chosenDeviceID = getRequestedDeviceID(requestedDeviceName, typeRequested);
+        if (chosenDeviceID == kAudioDeviceUnknown) {
+            printf("Could not find an audio device named \"%s\" of type %s.  Nothing was changed.\n",requestedDeviceName, deviceTypeName(typeRequested));
+            return 1;
+        }
+        strcpy(printableDeviceName, requestedDeviceName);
+    }
 	
 	// choose the requested audio device
 	setDevice(chosenDeviceID, typeRequested);
-	printf("%s audio device set to \"%s\"\n", deviceTypeName(typeRequested), requestedDeviceName);
-	return 0;
-	
+	printf("%s audio device set to \"%s\"\n", deviceTypeName(typeRequested), printableDeviceName);
+
+    return 0;
 }
 
 

--- a/audio_switch.c
+++ b/audio_switch.c
@@ -396,15 +396,16 @@ void showAllDevices(ASDeviceType typeRequested, ASOutputType outputRequested) {
 		}
 
 		getDeviceName(dev_array[i], deviceName);
+
 		switch(outputRequested) {
 			case kFormatHuman:
-				printf("%s (%s)\n",deviceName,deviceTypeName(device_type));
+				printf("%s (%s) (ID: %u)\n",deviceName,deviceTypeName(device_type),dev_array[i]);
 				break;
 			case kFormatCLI:
-				printf("%s,%s\n",deviceName,deviceTypeName(device_type));
+				printf("%s,%s,%u\n",deviceName,deviceTypeName(device_type),dev_array[i]);
 				break;
 			case kFormatJSON:
-				printf("{\"name\": \"%s\", \"type\": \"%s\"}\n",deviceName,deviceTypeName(device_type));
+				printf("{\"name\": \"%s\", \"type\": \"%s\", \"id\": \"%u\"}\n",deviceName,deviceTypeName(device_type),dev_array[i]);
 				break;
 			default:
 				break;

--- a/audio_switch.h
+++ b/audio_switch.h
@@ -48,11 +48,12 @@ typedef enum {
 } ASOutputType;
 
 enum {
-	kFunctionSetDevice   = 1,
-	kFunctionShowHelp    = 2,
-	kFunctionShowAll     = 3,
-	kFunctionShowCurrent = 4,
-	kFunctionCycleNext   = 5
+	kFunctionSetDeviceByName = 1,
+	kFunctionShowHelp        = 2,
+	kFunctionShowAll         = 3,
+	kFunctionShowCurrent     = 4,
+	kFunctionCycleNext       = 5,
+    kFunctionSetDeviceByID   = 6
 };
 
 

--- a/audio_switch.h
+++ b/audio_switch.h
@@ -53,13 +53,16 @@ enum {
 	kFunctionShowAll         = 3,
 	kFunctionShowCurrent     = 4,
 	kFunctionCycleNext       = 5,
-    kFunctionSetDeviceByID   = 6
+    kFunctionSetDeviceByID   = 6,
+    kFunctionSetDeviceByUID  = 7
 };
 
 
 
 void showUsage(const char * appName);
 int runAudioSwitch(int argc, const char * argv[]);
+char * getDeviceUID(AudioDeviceID deviceID);
+AudioDeviceID getRequestedDeviceIDFromUIDSubstring(char * requestedDeviceUID, ASDeviceType typeRequested);
 AudioDeviceID getCurrentlySelectedDeviceID(ASDeviceType typeRequested);
 void getDeviceName(AudioDeviceID deviceID, char * deviceName);
 ASDeviceType getDeviceType(AudioDeviceID deviceID);


### PR DESCRIPTION
Merges commits from @m3g0byt3 that added support for displaying and setting by device ID.

Also adds support for Device UID. See below for why this is necessary in some situations:

> The device ID is not consistent when unplugging and re-plugging an external audio source (it is some sort of counter). So this presents a problem when you want to choose a specific device.
> 
> macOS exposes a UID string for each audio device. The format of this string is a black box. For example, for built-in devices it is a simple string like BuiltInSpeakerDevice, but for a DisplayPort device it may be something like AppleGFXHDAEngineOutputDP:30001:0:{AD19-43B2-5257260B}. In the second case, the same device may appear as AppleGFXHDAEngineOutputDP:30001:1:{AD19-43B2-5257260B} if it is the second DisplayPort device currently plugged in.
> 
> So to support switching inputs by UID, this PR checks against a substring and it is left to the user to find the unique portion of the string. For the above example, running SwitchAudioSource -u AD19-43B2-5257260B always selects the appropriate device.