### PR TITLE
Add a type of 'all' to set all types in one command

### DIFF
--- a/audio_switch.c
+++ b/audio_switch.c
@@ -35,7 +35,7 @@ void showUsage(const char * appName) {
            "  -a             : shows all devices\n"
            "  -c             : shows current device\n\n"
            "  -f format      : output format (cli/human/json). Defaults to human.\n"
-           "  -t type        : device type (input/output/system).  Defaults to output.\n"
+           "  -t type        : device type (input/output/system/all).  Defaults to output.\n"
            "  -n             : cycles the audio device to the next one\n"
            "  -i device_id   : sets the audio device to the given device by id\n"
            "  -u device_uid  : sets the audio device to the given device by uid or a substring of the uid\n"
@@ -112,8 +112,10 @@ int runAudioSwitch(int argc, const char * argv[]) {
 					typeRequested = kAudioTypeInput;
 				} else if (strcmp(optarg, "output") == 0) {
 					typeRequested = kAudioTypeOutput;
-				} else if (strcmp(optarg, "system") == 0) {
-					typeRequested = kAudioTypeSystemOutput;
+                } else if (strcmp(optarg, "system") == 0) {
+                    typeRequested = kAudioTypeSystemOutput;
+                } else if (strcmp(optarg, "all") == 0) {
+                    typeRequested = kAudioTypeAll;
 				} else {
 					printf("Invalid device type \"%s\" specified.\n",optarg);
 					showUsage(argv[0]);
@@ -454,7 +456,7 @@ void setDevice(AudioDeviceID newDeviceID, ASDeviceType typeRequested) {
 	UInt32 propertySize = sizeof(UInt32);
 
 	switch(typeRequested) {
-		case kAudioTypeInput: 
+		case kAudioTypeInput:
 			AudioHardwareSetProperty(kAudioHardwarePropertyDefaultInputDevice, propertySize, &newDeviceID);
 			break;
 		case kAudioTypeOutput:
@@ -463,7 +465,12 @@ void setDevice(AudioDeviceID newDeviceID, ASDeviceType typeRequested) {
 		case kAudioTypeSystemOutput:
 			AudioHardwareSetProperty(kAudioHardwarePropertyDefaultSystemOutputDevice, propertySize, &newDeviceID);
 			break;
-        default: break;
+		case kAudioTypeAll:
+			AudioHardwareSetProperty(kAudioHardwarePropertyDefaultInputDevice, propertySize, &newDeviceID);
+			AudioHardwareSetProperty(kAudioHardwarePropertyDefaultOutputDevice, propertySize, &newDeviceID);
+			AudioHardwareSetProperty(kAudioHardwarePropertyDefaultSystemOutputDevice, propertySize, &newDeviceID);
+			break;
+		default: break;
 	}
 	
 }

--- a/audio_switch.c
+++ b/audio_switch.c
@@ -44,9 +44,9 @@ void showUsage(const char * appName) {
 
 int runAudioSwitch(int argc, const char * argv[]) {
 	char requestedDeviceName[256];
-    char printableDeviceName[256];
-    int requestedDeviceID;
-    char requestedDeviceUID[256];
+	char printableDeviceName[256];
+	int requestedDeviceID;
+	char requestedDeviceUID[256];
 	AudioDeviceID chosenDeviceID = kAudioDeviceUnknown;
 	ASDeviceType typeRequested = kAudioTypeUnknown;
 	ASOutputType outputRequested = kFormatHuman;
@@ -91,20 +91,20 @@ int runAudioSwitch(int argc, const char * argv[]) {
 			case 'i':
 				// set the requestedDeviceID
 				function = kFunctionSetDeviceByID;
-                requestedDeviceID = atoi(optarg);
+				requestedDeviceID = atoi(optarg);
 				break;
 
-            case 'u':
-                // set the requestedDeviceUID
-                function = kFunctionSetDeviceByUID;
-                strcpy(requestedDeviceUID, optarg);
-                break;
+			case 'u':
+				// set the requestedDeviceUID
+				function = kFunctionSetDeviceByUID;
+				strcpy(requestedDeviceUID, optarg);
+				break;
 
-            case 's':
-                // set the requestedDeviceName
-                function = kFunctionSetDeviceByName;
-                strcpy(requestedDeviceName, optarg);
-                break;
+			case 's':
+				// set the requestedDeviceName
+				function = kFunctionSetDeviceByName;
+				strcpy(requestedDeviceName, optarg);
+				break;
 
 			case 't':
 				// set the requestedDeviceName
@@ -112,10 +112,10 @@ int runAudioSwitch(int argc, const char * argv[]) {
 					typeRequested = kAudioTypeInput;
 				} else if (strcmp(optarg, "output") == 0) {
 					typeRequested = kAudioTypeOutput;
-                } else if (strcmp(optarg, "system") == 0) {
-                    typeRequested = kAudioTypeSystemOutput;
-                } else if (strcmp(optarg, "all") == 0) {
-                    typeRequested = kAudioTypeAll;
+				} else if (strcmp(optarg, "system") == 0) {
+					typeRequested = kAudioTypeSystemOutput;
+				} else if (strcmp(optarg, "all") == 0) {
+					typeRequested = kAudioTypeAll;
 				} else {
 					printf("Invalid device type \"%s\" specified.\n",optarg);
 					showUsage(argv[0]);

--- a/audio_switch.h
+++ b/audio_switch.h
@@ -38,7 +38,8 @@ typedef enum {
 	kAudioTypeUnknown = 0,
 	kAudioTypeInput   = 1,
 	kAudioTypeOutput  = 2,
-	kAudioTypeSystemOutput = 3
+	kAudioTypeSystemOutput = 3,
+	kAudioTypeAll = 4
 } ASDeviceType;
 
 typedef enum {


### PR DESCRIPTION
Full disclosure, I am unsure if this works. 

The build succeeds but I haven't dug into figure out where the build outputs to / if it actually does what I hope it will do. This came out of a frustration of my audio switching for output but then not for SMS chimes or for my input mic for Zoom calls.