### PR TITLE
Add flag for setting the `mute` flag on an audio device

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,25 @@ SwitchAudioSource [-a] [-c] [-f format] [-t type] [-n] -s device\_name | -i devi
  - **-c**               : shows current device
  - **-f** _format_      : output format (cli/human/json). Defaults to human.
  - **-t** _type_        : device type (input/output/system).  Defaults to output.
+ - **-m** _mute_mode_   : sets the mute status (mute/unmute/toggle).
  - **-n**               : cycles the audio device to the next one
  - **-i** _device_id_   : sets the audio device to the given device by id
  - **-u** _device_uid_  : sets the audio device to the given device by uid or a substring of the uid
  - **-s** _device_name_ : sets the audio device to the given device by name
 
+### Muting
+
+The `-m` flag can be used to mute input or output devices.
+
+Define the device via `-t`.
+
+Example for toggling the mute state for the currently selected input, e.g. microphone:
+
+```shell
+SwitchAudioSource -m toggle -t input
+```
+
+This is useful on a hotkey, e.g. to mute your Teams or Zoom input.
 
 Thanks
 -------

--- a/audio_switch.h
+++ b/audio_switch.h
@@ -32,13 +32,15 @@ OTHER DEALINGS IN THE SOFTWARE.
 #include <unistd.h>
 #include <CoreServices/CoreServices.h>
 #include <CoreAudio/CoreAudio.h>
+#include <CoreAudio/AudioHardware.h>
+#include <CoreAudio/AudioHardwareBase.h>
 
 
 typedef enum {
 	kAudioTypeUnknown = 0,
 	kAudioTypeInput   = 1,
 	kAudioTypeOutput  = 2,
-	kAudioTypeSystemOutput = 3
+	kAudioTypeSystemOutput = 3,
 } ASDeviceType;
 
 typedef enum {
@@ -47,6 +49,12 @@ typedef enum {
 	kFormatJSON = 2,
 } ASOutputType;
 
+typedef enum {
+	kUnmute = 0,
+	kMute = 1,
+	kToggleMute = 2,
+} ASMuteType;
+
 enum {
 	kFunctionSetDeviceByName = 1,
 	kFunctionShowHelp        = 2,
@@ -54,7 +62,8 @@ enum {
 	kFunctionShowCurrent     = 4,
 	kFunctionCycleNext       = 5,
     kFunctionSetDeviceByID   = 6,
-    kFunctionSetDeviceByUID  = 7
+    kFunctionSetDeviceByUID  = 7,
+	kFunctionMute            = 8,
 };
 
 
@@ -73,4 +82,5 @@ void showCurrentlySelectedDeviceID(ASDeviceType typeRequested, ASOutputType outp
 AudioDeviceID getRequestedDeviceID(char * requestedDeviceName, ASDeviceType typeRequested);
 AudioDeviceID getNextDeviceID(AudioDeviceID currentDeviceID, ASDeviceType typeRequested);
 void setDevice(AudioDeviceID newDeviceID, ASDeviceType typeRequested);
+OSStatus setMute(ASDeviceType typeRequested, ASMuteType mute);
 void showAllDevices(ASDeviceType typeRequested, ASOutputType outputRequested);


### PR DESCRIPTION
The mute flag can be set on input and output devices via CoreAudio. For input devices this is not exposed in the UI, besides via the _Audio MIDI Setup_ utility.

The benefit over just reducing the volume to 0, which also turns on the `mute` flag is that just toggling the flag keeps the volume level defined before, when unmuting.

This PR introduces a new flag (`-m`) that allows muting, unmuting or toggling based on the current mute state.

I've mapped this to a hotkey that allows me to reliably mute, e.g. during Teams calls.