### PR TITLE
Checks whether the device we switch to is Microsoft Teams and skips it

### DIFF
--- a/audio_switch.c
+++ b/audio_switch.c
@@ -435,6 +435,12 @@ AudioDeviceID getNextDeviceID(AudioDeviceID currentDeviceID, ASDeviceType typeRe
 				break;
             default: break;
 		}
+        
+        char nextDeviceName[256];
+        getDeviceName(dev_array[i], nextDeviceName);
+        if (strstr(nextDeviceName, "Microsoft Teams")) {
+            continue;
+        }
 
 		if (first_dev == kAudioDeviceUnknown) {
 			first_dev = dev_array[i];


### PR DESCRIPTION
Microsoft teams device causes 'next' option to fail to cycle through devices. 