### PR TITLE
Cannot switch audio device by "uid", the '-u' argument; 'Could not find an audio device with UID' error

### DIFF
--- a/audio_switch.c
+++ b/audio_switch.c
@@ -321,12 +321,13 @@ AudioDeviceID getRequestedDeviceIDFromUIDSubstring(char * requestedDeviceUID, AS
         }
 
         char deviceUID[256];
+        CFStringRef deviceUIDRef = NULL;
         propertyAddress.mSelector = kAudioDevicePropertyDeviceUID;
         propertyAddress.mScope = kAudioObjectPropertyScopeGlobal;
         propertyAddress.mElement = dev_array[i];
-        propertySize = sizeof(deviceUID);
-        AudioObjectGetPropertyData(dev_array[i], &propertyAddress, 0, NULL, &propertySize, &deviceUID);
-
+        propertySize = sizeof(deviceUIDRef);
+        AudioObjectGetPropertyData(dev_array[i], &propertyAddress, 0, NULL, &propertySize, &deviceUIDRef);
+        CFStringGetCString(deviceUIDRef, deviceUID, sizeof(deviceUID), CFStringGetSystemEncoding());
         if (strstr(deviceUID, requestedDeviceUID) != NULL) {
             return dev_array[i];
         }


### PR DESCRIPTION
AudioObjectGetPropertyData uses CFStringRef instead of raw char buffer.  This patch fixes it.
I would also add some error checking to the code, but I wanted to keep the changes minimal.