### PR TITLE
Fix build when run on pre-macOS Monterey

### DIFF
--- a/audio_switch.c
+++ b/audio_switch.c
@@ -715,7 +715,11 @@ OSStatus setMute(ASDeviceType typeRequested, ASMuteType muteRequested) {
     AudioObjectPropertyAddress propertyAddress = {
         .mSelector  = kAudioDevicePropertyMute,
         .mScope     = scope,
+        #ifndef MAC_OS_VERSION_12_0
+        .mElement   = kAudioObjectPropertyElementMaster,
+        #else
         .mElement   = kAudioObjectPropertyElementMain,
+        #endif
     };
 
     UInt32 muted = (UInt32)muteRequested;


### PR DESCRIPTION
When run on macOS versions before Monterey (12.0), [the `kAudioObjectPropertyElementMain` constant does not exist](https://developer.apple.com/documentation/coreaudio/kaudioobjectpropertyelementmain), resulting in a failed build. This is equivalent to [the deprecated `kAudioObjectPropertyElementMaster` constant](https://developer.apple.com/documentation/coreaudio/kaudioobjectpropertyelementmaster), which does work. This PR adds a `#ifndef` to use the old constant pre-Monterey which fixes builds on older macOS versions (e.g. Catalina and Big Sur).