### PR TITLE
audio_switch.h: fix for pre-10.8

### DIFF
--- a/audio_switch.h
+++ b/audio_switch.h
@@ -33,8 +33,17 @@ OTHER DEALINGS IN THE SOFTWARE.
 #include <CoreServices/CoreServices.h>
 #include <CoreAudio/CoreAudio.h>
 #include <CoreAudio/AudioHardware.h>
+#include <AvailabilityMacros.h>
+#ifndef MAC_OS_X_VERSION_10_8 // fallbacks for < 10.8
+#define kAudioObjectPropertyScopeInput kAudioDevicePropertyScopeInput
+#define kAudioObjectPropertyScopeOutput kAudioDevicePropertyScopeOutput
+#else
 #include <CoreAudio/AudioHardwareBase.h>
+#endif
 
+#ifndef kAudioObjectPropertyElementMain
+#define kAudioObjectPropertyElementMain kAudioObjectPropertyElementMaster
+#endif
 
 typedef enum {
 	kAudioTypeUnknown = 0,


### PR DESCRIPTION
`<CoreAudio/AudioHardwareBase.h>` appears in 10.8. Fallback definitions are from https://github.com/phracker/MacOSX-SDKs/blob/041600eda65c6a668f66cb7d56b7d1da3e8bcc93/MacOSX10.8.sdk/System/Library/Frameworks/CoreAudio.framework/Versions/A/Headers/AudioHardwareDeprecated.h#L52-L53

With this it builds at least on 10.6.