### PR TITLE
adding the capability to set speakers for atmos layout 

### DIFF
--- a/audio_switch.h
+++ b/audio_switch.h
@@ -56,6 +56,13 @@ typedef enum {
 	kToggleMute = 2,
 } ASMuteType;
 
+typedef enum {
+    kL5_1_4 = 0,
+    kL7_1_2 = 1,
+    kL9_1_6 = 2,
+}
+ASLayoutType;
+
 enum {
 	kFunctionSetDeviceByName = 1,
 	kFunctionShowHelp        = 2,
@@ -65,6 +72,7 @@ enum {
     kFunctionSetDeviceByID   = 6,
     kFunctionSetDeviceByUID  = 7,
 	kFunctionMute            = 8,
+    kFunctionLayout          = 9,
 };
 
 
@@ -88,4 +96,5 @@ int setAllDevicesByName(char * requestedDeviceName);
 int cycleNext(ASDeviceType typeRequested);
 int cycleNextForOneDevice(ASDeviceType typeRequested);
 OSStatus setMute(ASDeviceType typeRequested, ASMuteType mute);
+OSStatus setSpeakerLayout(ASDeviceType typeRequested, ASLayoutType layoutRequested, int * channelNumber);
 void showAllDevices(ASDeviceType typeRequested, ASOutputType outputRequested);


### PR DESCRIPTION
adding the capability to set speakers for Atmos layout not found in Audio-Midi Setup utility.

5.1.4, 7.1.2, 9.1.6 are Atmos layout found in coreaudio, however while the Audio-Midi Setup utility had these layout available in speaker configuration in a few version of MacOS, they are no longer found.

This PR allows you to set this speaker layouts using this utility.

Tested on my MacOS with my 5.1.4 setup.